### PR TITLE
feat: switch site styling to night theme

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,10 +1,10 @@
 export default function Page() {
   return (
-    <main className="mx-auto max-w-4xl px-6 py-20">
+    <main className="mx-auto max-w-4xl px-6 py-20 text-slate-300">
       <header className="mb-16">
-        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">About the Foundation</p>
-        <h1 className="mt-4 text-4xl font-bold tracking-tight text-gray-900">Stewarding the IPPAN Network</h1>
-        <p className="mt-6 text-lg text-gray-700">
+        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-400">About the Foundation</p>
+        <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-100">Stewarding the IPPAN Network</h1>
+        <p className="mt-6 text-lg text-slate-300">
           The IPPAN Foundation is a non-profit organization dedicated to advancing the adoption and long-term sustainability of
           the IPPAN Network. We ensure the protocol remains open, neutral, and resilient so builders everywhere can innovate with
           confidence.
@@ -12,67 +12,67 @@ export default function Page() {
       </header>
 
       <section className="space-y-10">
-        <article className="rounded-3xl border p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-gray-900">Our Mandate</h2>
-          <p className="mt-4 text-gray-700">
+        <article className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-slate-100">Our Mandate</h2>
+          <p className="mt-4 text-slate-300">
             Founded to protect the core protocol, govern open standards, and support ecosystem growth, the Foundation acts as a
             long-term steward of the IPPAN Network. We coordinate technical roadmaps, align stakeholders, and advocate for
             responsible decentralization across jurisdictions.
           </p>
         </article>
 
-        <article className="rounded-3xl border p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-gray-900">Mission Pillars</h2>
+        <article className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-slate-100">Mission Pillars</h2>
           <div className="mt-6 grid gap-6 sm:grid-cols-2">
             <div>
-              <h3 className="text-lg font-semibold text-gray-900">Protocol Evolution</h3>
-              <p className="mt-2 text-sm text-gray-600">
+              <h3 className="text-lg font-semibold text-slate-100">Protocol Evolution</h3>
+              <p className="mt-2 text-sm text-slate-300">
                 Maintain and advance the IPPAN protocol for security, performance, and interoperability through transparent
                 research and development.
               </p>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-gray-900">Developer Empowerment</h3>
-              <p className="mt-2 text-sm text-gray-600">
+              <h3 className="text-lg font-semibold text-slate-100">Developer Empowerment</h3>
+              <p className="mt-2 text-sm text-slate-300">
                 Support builders with open-source tooling, technical documentation, grants, and mentorship opportunities.
               </p>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-gray-900">Open Participation</h3>
-              <p className="mt-2 text-sm text-gray-600">
+              <h3 className="text-lg font-semibold text-slate-100">Open Participation</h3>
+              <p className="mt-2 text-sm text-slate-300">
                 Encourage global node participation and community decision-making that keeps the network credibly neutral.
               </p>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-gray-900">Responsible Growth</h3>
-              <p className="mt-2 text-sm text-gray-600">
+              <h3 className="text-lg font-semibold text-slate-100">Responsible Growth</h3>
+              <p className="mt-2 text-sm text-slate-300">
                 Champion sustainability initiatives, regulatory clarity, and ethical deployment of decentralized infrastructure.
               </p>
             </div>
           </div>
         </article>
 
-        <article className="rounded-3xl border p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-gray-900">Technology Stewardship</h2>
-          <p className="mt-4 text-gray-700">
+        <article className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-slate-100">Technology Stewardship</h2>
+          <p className="mt-4 text-slate-300">
             IPPAN introduces breakthrough innovations—HashTimer™ ordering, an energy-efficient BlockDAG architecture, a
             self-healing peer-to-peer network, human-readable naming, and machine-to-machine payment rails. The Foundation
             safeguards these capabilities while promoting interoperability with emerging standards.
           </p>
         </article>
 
-        <article className="rounded-3xl border p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-gray-900">Programs & Partnerships</h2>
-          <p className="mt-4 text-gray-700">
+        <article className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-slate-100">Programs & Partnerships</h2>
+          <p className="mt-4 text-slate-300">
             Our grants, infrastructure incentives, educational initiatives, and strategic partnerships accelerate innovation across
             the ecosystem. We collaborate with universities, enterprises, regulators, and open-source communities to ensure IPPAN
             delivers meaningful impact for people and machines worldwide.
           </p>
         </article>
 
-        <article className="rounded-3xl border p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-gray-900">Transparency & Governance</h2>
-          <p className="mt-4 text-gray-700">
+        <article className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-slate-100">Transparency & Governance</h2>
+          <p className="mt-4 text-slate-300">
             The Foundation operates with accountability and openness. Treasury allocations, research outputs, and protocol updates
             are reported publicly, with community forums and working groups driving consensus on the network&apos;s direction.
           </p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -7,11 +7,11 @@ const contacts = [
 
 export default function Contact() {
   return (
-    <main className="mx-auto max-w-4xl px-6 py-20">
+    <main className="mx-auto max-w-4xl px-6 py-20 text-slate-300">
       <header className="mb-16">
-        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Contact</p>
-        <h1 className="mt-4 text-4xl font-bold tracking-tight text-gray-900">Connect with the Foundation</h1>
-        <p className="mt-6 text-lg text-gray-700">
+        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-400">Contact</p>
+        <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-100">Connect with the Foundation</h1>
+        <p className="mt-6 text-lg text-slate-300">
           We welcome collaboration with developers, enterprises, researchers, and policymakers who share our vision for
           decentralized, sustainable infrastructure. Reach out to the teams below and we&apos;ll follow up promptly.
         </p>
@@ -19,17 +19,20 @@ export default function Contact() {
 
       <section className="grid gap-6 sm:grid-cols-2">
         {contacts.map((item) => (
-          <div key={item.label} className="rounded-3xl border p-6 shadow-sm">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">{item.label}</h2>
-            <a href={`mailto:${item.value}`} className="mt-3 block text-lg font-medium text-indigo-600 hover:text-indigo-700">
+          <div key={item.label} className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">{item.label}</h2>
+            <a
+              href={`mailto:${item.value}`}
+              className="mt-3 block text-lg font-medium text-indigo-300 transition hover:text-indigo-200"
+            >
               {item.value}
             </a>
           </div>
         ))}
       </section>
 
-      <section className="mt-16 rounded-3xl border bg-slate-50 p-10 text-sm text-gray-600">
-        <h2 className="text-lg font-semibold text-gray-900">Stay in the loop</h2>
+      <section className="mt-16 rounded-3xl border border-slate-800 bg-slate-900/60 p-10 text-sm text-slate-300 shadow-xl shadow-slate-950/40">
+        <h2 className="text-lg font-semibold text-slate-100">Stay in the loop</h2>
         <p className="mt-3">
           Subscribe to the Foundation briefing for governance updates, ecosystem highlights, and upcoming community calls. We
           respect your privacy and will only send essential communications.

--- a/app/forum/page.tsx
+++ b/app/forum/page.tsx
@@ -328,22 +328,22 @@ export default function ForumPage() {
   }
 
   return (
-    <main className="mx-auto max-w-6xl px-6 py-16">
+    <main className="mx-auto max-w-6xl px-6 py-16 text-slate-300">
       <header className="mb-14 space-y-5">
-        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">Community Forum</p>
-        <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">Join the professional IPPAN network</h1>
-        <p className="max-w-3xl text-lg text-gray-700">
+        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-400">Community Forum</p>
+        <h1 className="text-4xl font-bold tracking-tight text-slate-100 sm:text-5xl">Join the professional IPPAN network</h1>
+        <p className="max-w-3xl text-lg text-slate-300">
           Exchange expertise with researchers, engineers, node operators, and public sector partners building on IPPAN. Register
           with your professional email to unlock posting, start new initiatives, and collaborate on programmes that accelerate
           resilient digital infrastructure worldwide.
         </p>
-        <div className="flex flex-wrap gap-4 text-sm text-gray-600">
-          <div className="flex items-center gap-2 rounded-full border border-indigo-100 bg-indigo-50 px-4 py-1 text-indigo-700">
-            <span className="h-2 w-2 rounded-full bg-indigo-600" aria-hidden />
+        <div className="flex flex-wrap gap-4 text-sm text-slate-300">
+          <div className="flex items-center gap-2 rounded-full border border-indigo-500/40 bg-indigo-500/10 px-4 py-1 text-indigo-200">
+            <span className="h-2 w-2 rounded-full bg-indigo-400" aria-hidden />
             Real names & verified email identities keep discussions constructive.
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1 text-emerald-700">
-            <span className="h-2 w-2 rounded-full bg-emerald-600" aria-hidden />
+          <div className="flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-4 py-1 text-emerald-200">
+            <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
             Moderated by the IPPAN Foundation community team.
           </div>
         </div>
@@ -351,21 +351,21 @@ export default function ForumPage() {
 
       <section className="grid gap-10 lg:grid-cols-[300px,1fr]">
         <aside className="flex flex-col gap-8">
-          <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-gray-900">Forum access</h2>
+              <h2 className="text-lg font-semibold text-slate-100">Forum access</h2>
               {user ? (
-                <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Active member</span>
+                <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200">Active member</span>
               ) : (
-                <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600">Registration required</span>
+                <span className="rounded-full bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-300">Registration required</span>
               )}
             </div>
 
             {user ? (
-              <div className="mt-5 space-y-4 text-sm text-gray-700">
+              <div className="mt-5 space-y-4 text-sm text-slate-300">
                 <div>
-                  <p className="font-medium text-gray-900">{user.displayName}</p>
-                  <p className="text-gray-500">{user.email}</p>
+                  <p className="font-medium text-slate-100">{user.displayName}</p>
+                  <p className="text-slate-400">{user.email}</p>
                 </div>
                 <p>
                   You are authorised to publish threads and replies. Keep conversations focused, actionable, and aligned with the
@@ -374,19 +374,19 @@ export default function ForumPage() {
                 <button
                   type="button"
                   onClick={handleSignOut}
-                  className="inline-flex items-center justify-center rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:border-gray-400 hover:text-gray-900"
+                  className="inline-flex items-center justify-center rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white"
                 >
                   Sign out
                 </button>
               </div>
             ) : (
-              <form onSubmit={handleRegister} className="mt-5 space-y-4 text-sm text-gray-700">
-                <p className="text-gray-600">
+              <form onSubmit={handleRegister} className="mt-5 space-y-4 text-sm text-slate-300">
+                <p className="text-slate-400">
                   Register with your organisation email to participate. A confirmation link will be sent to authorise posting
                   privileges.
                 </p>
                 <div>
-                  <label htmlFor="displayName" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-gray-500">
+                  <label htmlFor="displayName" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-slate-400">
                     Full name
                   </label>
                   <input
@@ -394,11 +394,11 @@ export default function ForumPage() {
                     name="displayName"
                     required
                     placeholder="Ada Lovelace"
-                    className="w-full rounded-2xl border border-gray-200 px-4 py-2.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-2.5 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                   />
                 </div>
                 <div>
-                  <label htmlFor="email" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-gray-500">
+                  <label htmlFor="email" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-slate-400">
                     Work email
                   </label>
                   <input
@@ -407,14 +407,14 @@ export default function ForumPage() {
                     type="email"
                     required
                     placeholder="you@organisation.com"
-                    className="w-full rounded-2xl border border-gray-200 px-4 py-2.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-2.5 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                   />
                 </div>
-                {registerError && <p className="text-sm font-medium text-rose-600">{registerError}</p>}
-                {registerSuccess && <p className="text-sm font-medium text-emerald-600">{registerSuccess}</p>}
+                {registerError && <p className="text-sm font-medium text-rose-500">{registerError}</p>}
+                {registerSuccess && <p className="text-sm font-medium text-emerald-400">{registerSuccess}</p>}
                 <button
                   type="submit"
-                  className="w-full rounded-full bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+                  className="w-full rounded-full bg-indigo-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400"
                 >
                   Send access link
                 </button>
@@ -422,9 +422,9 @@ export default function ForumPage() {
             )}
           </div>
 
-          <div className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h2 className="text-lg font-semibold text-gray-900">Discussion tracks</h2>
-            <p className="mt-2 text-sm text-gray-600">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40">
+            <h2 className="text-lg font-semibold text-slate-100">Discussion tracks</h2>
+            <p className="mt-2 text-sm text-slate-300">
               Choose a track to focus threads by expertise. Admin moderators ensure every topic receives timely review.
             </p>
             <ul className="mt-5 space-y-4">
@@ -434,13 +434,13 @@ export default function ForumPage() {
                   onClick={() => setSelectedCategoryId('all')}
                   className={`flex w-full items-start justify-between rounded-2xl border px-4 py-3 text-left transition ${
                     selectedCategoryId === 'all'
-                      ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
-                      : 'border-transparent bg-gray-50 text-gray-700 hover:border-gray-200'
+                      ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200 shadow-lg shadow-indigo-500/20'
+                      : 'border-transparent bg-slate-900/60 text-slate-300 hover:border-slate-700'
                   }`}
                 >
                   <div>
                     <p className="text-sm font-semibold">All discussions</p>
-                    <p className="text-xs text-gray-500">View updates from every track.</p>
+                    <p className="text-xs text-slate-400">View updates from every track.</p>
                   </div>
                   <span className="text-xs font-semibold">{threads.length}</span>
                 </button>
@@ -454,13 +454,13 @@ export default function ForumPage() {
                       onClick={() => setSelectedCategoryId(category.id)}
                       className={`flex w-full items-start justify-between rounded-2xl border px-4 py-3 text-left transition ${
                         isSelected
-                          ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
-                          : 'border-transparent bg-gray-50 text-gray-700 hover:border-gray-200'
+                          ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200 shadow-lg shadow-indigo-500/20'
+                          : 'border-transparent bg-slate-900/60 text-slate-300 hover:border-slate-700'
                       }`}
                     >
                       <div>
                         <p className="text-sm font-semibold">{category.name}</p>
-                        <p className="text-xs text-gray-500">{category.description}</p>
+                        <p className="text-xs text-slate-400">{category.description}</p>
                       </div>
                       <span className="text-xs font-semibold">{categoryCounts[category.id] ?? 0}</span>
                     </button>
@@ -468,9 +468,9 @@ export default function ForumPage() {
                 )
               })}
             </ul>
-            <div className="mt-5 rounded-2xl bg-slate-900 p-4 text-sm text-slate-200">
+            <div className="mt-5 rounded-2xl border border-slate-800 bg-slate-950/80 p-4 text-sm text-slate-300">
               <p className="font-semibold text-white">Need help getting started?</p>
-              <p className="mt-1 text-slate-300">
+              <p className="mt-1 text-slate-400">
                 Read our <Link href="/legal/code-of-conduct" className="underline decoration-indigo-400">code of conduct</Link> and
                 <Link href="/contact" className="ml-1 underline decoration-indigo-400">contact the community team</Link> for onboarding
                 support.
@@ -480,15 +480,15 @@ export default function ForumPage() {
         </aside>
 
         <div className="space-y-10">
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+          <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-gray-900">Start a new discussion</h2>
-              <span className="text-xs uppercase tracking-widest text-gray-500">Share proposals, releases, or requests</span>
+              <h2 className="text-lg font-semibold text-slate-100">Start a new discussion</h2>
+              <span className="text-xs uppercase tracking-widest text-slate-400">Share proposals, releases, or requests</span>
             </div>
             <form onSubmit={handleCreateThread} className="mt-5 space-y-4">
               <div className="grid gap-4 md:grid-cols-[2fr,1fr]">
                 <div>
-                  <label htmlFor="thread-title" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-gray-500">
+                  <label htmlFor="thread-title" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-slate-400">
                     Title
                   </label>
                   <input
@@ -497,11 +497,11 @@ export default function ForumPage() {
                     value={threadForm.title}
                     onChange={(event) => setThreadForm((prev) => ({ ...prev, title: event.target.value }))}
                     placeholder="Summarise your topic in a sentence"
-                    className="w-full rounded-2xl border border-gray-200 px-4 py-2.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-2.5 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                   />
                 </div>
                 <div>
-                  <label htmlFor="thread-category" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-gray-500">
+                  <label htmlFor="thread-category" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-slate-400">
                     Track
                   </label>
                   <select
@@ -509,7 +509,7 @@ export default function ForumPage() {
                     name="thread-category"
                     value={threadForm.categoryId}
                     onChange={(event) => setThreadForm((prev) => ({ ...prev, categoryId: event.target.value }))}
-                    className="w-full rounded-2xl border border-gray-200 px-4 py-2.5 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                    className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-2.5 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                   >
                     {categories.map((category) => (
                       <option key={category.id} value={category.id}>
@@ -520,7 +520,7 @@ export default function ForumPage() {
                 </div>
               </div>
               <div>
-                <label htmlFor="thread-summary" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-gray-500">
+                <label htmlFor="thread-summary" className="mb-1 block text-xs font-semibold uppercase tracking-widest text-slate-400">
                   Opening message
                 </label>
                 <textarea
@@ -530,15 +530,15 @@ export default function ForumPage() {
                   onChange={(event) => setThreadForm((prev) => ({ ...prev, summary: event.target.value }))}
                   rows={4}
                   placeholder="Provide context, key data points, and a clear call to action for the community."
-                  className="w-full rounded-2xl border border-gray-200 px-4 py-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                  className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                 />
               </div>
-              {threadFormError && <p className="text-sm font-medium text-rose-600">{threadFormError}</p>}
+              {threadFormError && <p className="text-sm font-medium text-rose-500">{threadFormError}</p>}
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                {!user && <p className="text-sm text-gray-500">Registration required to publish a discussion.</p>}
+                {!user && <p className="text-sm text-slate-400">Registration required to publish a discussion.</p>}
                 <button
                   type="submit"
-                  className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                  className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-700"
                   disabled={!user}
                 >
                   Publish to forum
@@ -549,8 +549,8 @@ export default function ForumPage() {
 
           <section className="space-y-6">
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-gray-900">Latest discussions</h2>
-              <p className="text-sm text-gray-500">
+              <h2 className="text-lg font-semibold text-slate-100">Latest discussions</h2>
+              <p className="text-sm text-slate-400">
                 Showing {filteredThreads.length} {filteredThreads.length === 1 ? 'thread' : 'threads'} in{' '}
                 {selectedCategoryId === 'all'
                   ? 'all tracks'
@@ -559,9 +559,9 @@ export default function ForumPage() {
             </div>
 
             {filteredThreads.length === 0 ? (
-              <div className="rounded-3xl border border-dashed border-gray-300 bg-white p-10 text-center">
-                <p className="text-base font-semibold text-gray-900">No discussions yet in this track</p>
-                <p className="mt-2 text-sm text-gray-600">
+              <div className="rounded-3xl border border-dashed border-slate-700 bg-slate-900/60 p-10 text-center">
+                <p className="text-base font-semibold text-slate-100">No discussions yet in this track</p>
+                <p className="mt-2 text-sm text-slate-400">
                   Be the first to open a conversation and invite community members to contribute insights and resources.
                 </p>
               </div>
@@ -578,8 +578,8 @@ export default function ForumPage() {
                         onClick={() => setActiveThreadId(thread.id)}
                         className={`w-full rounded-2xl border px-5 py-4 text-left transition ${
                           isActive
-                            ? 'border-indigo-500 bg-indigo-50 text-indigo-800 shadow-sm'
-                            : 'border-gray-200 bg-white text-gray-700 hover:border-indigo-200'
+                            ? 'border-indigo-500 bg-indigo-500/10 text-indigo-200 shadow-lg shadow-indigo-500/20'
+                            : 'border-slate-800 bg-slate-900/60 text-slate-300 hover:border-indigo-500/60'
                         }`}
                       >
                         <div className="flex items-center justify-between text-xs uppercase tracking-widest">
@@ -587,49 +587,49 @@ export default function ForumPage() {
                           <span>{new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' }).format(new Date(thread.createdAt))}</span>
                         </div>
                         <p className="mt-2 text-sm font-semibold">{thread.title}</p>
-                        <p className="mt-1 line-clamp-2 text-xs text-gray-500">{thread.summary}</p>
-                        <p className="mt-3 text-xs text-gray-400">Started by {thread.author.displayName}</p>
+                        <p className="mt-1 line-clamp-2 text-xs text-slate-400">{thread.summary}</p>
+                        <p className="mt-3 text-xs text-slate-500">Started by {thread.author.displayName}</p>
                       </button>
                     )
                   })}
                 </div>
 
                 {activeThread && (
-                  <article className="flex flex-col justify-between rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+                  <article className="flex flex-col justify-between rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-slate-950/40">
                     <div>
-                      <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-widest text-gray-500">
+                      <div className="flex flex-wrap items-center justify-between gap-3 text-xs uppercase tracking-widest text-slate-400">
                         <span>
                           {categories.find((category) => category.id === activeThread.categoryId)?.name ?? 'General'} •{' '}
                           {formatDateTime(activeThread.createdAt)}
                         </span>
                         <span>Created by {activeThread.author.displayName}</span>
                       </div>
-                      <h3 className="mt-3 text-2xl font-semibold text-gray-900">{activeThread.title}</h3>
-                      <p className="mt-4 text-sm leading-relaxed text-gray-700">{activeThread.summary}</p>
+                      <h3 className="mt-3 text-2xl font-semibold text-slate-100">{activeThread.title}</h3>
+                      <p className="mt-4 text-sm leading-relaxed text-slate-300">{activeThread.summary}</p>
                     </div>
 
                     <div className="mt-6 space-y-5">
-                      <h4 className="text-sm font-semibold uppercase tracking-widest text-gray-500">
+                      <h4 className="text-sm font-semibold uppercase tracking-widest text-slate-400">
                         {activeThread.posts.length} {activeThread.posts.length === 1 ? 'Reply' : 'Replies'}
                       </h4>
                       <div className="space-y-4">
                         {activeThread.posts.map((post) => (
-                          <div key={post.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
-                            <div className="flex items-center justify-between text-xs text-gray-500">
-                              <span className="font-semibold text-gray-700">{post.author.displayName}</span>
+                          <div key={post.id} className="rounded-2xl border border-slate-800 bg-slate-950/60 p-4">
+                            <div className="flex items-center justify-between text-xs text-slate-400">
+                              <span className="font-semibold text-slate-200">{post.author.displayName}</span>
                               <span>{formatDateTime(post.createdAt)}</span>
                             </div>
-                            <p className="mt-3 text-sm leading-relaxed text-gray-700">{post.content}</p>
+                            <p className="mt-3 text-sm leading-relaxed text-slate-300">{post.content}</p>
                           </div>
                         ))}
                         {activeThread.posts.length === 0 && (
-                          <div className="rounded-2xl border border-dashed border-gray-300 p-6 text-center text-sm text-gray-500">
+                          <div className="rounded-2xl border border-dashed border-slate-700 p-6 text-center text-sm text-slate-400">
                             No replies yet. Share your insights to move this discussion forward.
                           </div>
                         )}
                       </div>
                       <form onSubmit={handleReply(activeThread.id)} className="space-y-3">
-                        <label htmlFor={`reply-${activeThread.id}`} className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+                        <label htmlFor={`reply-${activeThread.id}`} className="text-xs font-semibold uppercase tracking-widest text-slate-400">
                           Add your perspective
                         </label>
                         <textarea
@@ -644,16 +644,16 @@ export default function ForumPage() {
                           }
                           rows={4}
                           placeholder={user ? 'Share data, observations, or next steps for the group.' : 'Register to add your reply.'}
-                          className="w-full rounded-2xl border border-gray-200 px-4 py-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                          className="w-full rounded-2xl border border-slate-700 bg-slate-950/60 px-4 py-3 text-sm text-slate-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30"
                         />
                         {replyErrors[activeThread.id] && (
-                          <p className="text-sm font-medium text-rose-600">{replyErrors[activeThread.id]}</p>
+                          <p className="text-sm font-medium text-rose-500">{replyErrors[activeThread.id]}</p>
                         )}
                         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                          {!user && <p className="text-sm text-gray-500">Register to unlock replies.</p>}
+                          {!user && <p className="text-sm text-slate-400">Register to unlock replies.</p>}
                           <button
                             type="submit"
-                            className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-gray-300"
+                            className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:bg-slate-700"
                             disabled={!user}
                           >
                             Post reply

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,16 +21,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="en">
-      <body className="min-h-screen bg-white text-gray-900 antialiased">
+      <body className="min-h-screen bg-slate-950 text-slate-100 antialiased">
         <div className="flex min-h-screen flex-col">
-          <header className="border-b bg-white/80 backdrop-blur">
+          <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
             <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
-              <Link href="/" className="text-xl font-semibold tracking-tight">
+              <Link href="/" className="text-xl font-semibold tracking-tight text-slate-100">
                 IPPAN Foundation
               </Link>
-              <nav className="flex items-center gap-6 text-sm font-medium text-gray-600">
+              <nav className="flex items-center gap-6 text-sm font-medium text-slate-300">
                 {navLinks.map((link) => (
-                  <Link key={link.href} href={link.href} className="transition hover:text-gray-900">
+                  <Link key={link.href} href={link.href} className="transition hover:text-white">
                     {link.label}
                   </Link>
                 ))}
@@ -38,10 +38,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </header>
           <main className="flex-1">{children}</main>
-          <footer className="border-t bg-gray-50">
-            <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-10 text-sm text-gray-600 sm:flex-row sm:items-center sm:justify-between">
-              <p>© {currentYear} IPPAN Foundation. All rights reserved.</p>
-              <p className="text-gray-500">
+          <footer className="border-t border-slate-800 bg-slate-950">
+            <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-10 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-slate-300">© {currentYear} IPPAN Foundation. All rights reserved.</p>
+              <p className="text-slate-500">
                 Advancing decentralized, resilient, and sustainable digital infrastructure for all.
               </p>
             </div>

--- a/app/legal/page.tsx
+++ b/app/legal/page.tsx
@@ -1,6 +1,6 @@
 export default function Legal() {
   return (
-    <div className="prose">
+    <div className="prose prose-invert">
       <h1>Legal</h1>
       <p>Terms of Use and Privacy Policy to be published by the Foundation.</p>
     </div>

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -18,11 +18,11 @@ const updates = [
 
 export default function NewsPage() {
   return (
-    <main className="mx-auto max-w-4xl px-6 py-20">
+    <main className="mx-auto max-w-4xl px-6 py-20 text-slate-300">
       <header className="mb-16">
-        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">News & Updates</p>
-        <h1 className="mt-4 text-4xl font-bold tracking-tight text-gray-900">Latest from the IPPAN Foundation</h1>
-        <p className="mt-6 text-lg text-gray-700">
+        <p className="text-sm font-semibold uppercase tracking-widest text-indigo-400">News & Updates</p>
+        <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-100">Latest from the IPPAN Foundation</h1>
+        <p className="mt-6 text-lg text-slate-300">
           Stay informed on protocol development, community initiatives, and opportunities to contribute. Highlights below are
           refreshed regularly, with detailed briefings distributed through the Foundation newsletter.
         </p>
@@ -30,10 +30,13 @@ export default function NewsPage() {
 
       <section className="space-y-6">
         {updates.map((item) => (
-          <article key={item.title} className="rounded-3xl border p-8 shadow-sm">
-            <h2 className="text-2xl font-semibold text-gray-900">{item.title}</h2>
-            <p className="mt-3 text-sm text-gray-600">{item.description}</p>
-            <p className="mt-6 text-sm text-indigo-600">Full briefings coming soon.</p>
+          <article
+            key={item.title}
+            className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-slate-300 shadow-xl shadow-slate-950/40"
+          >
+            <h2 className="text-2xl font-semibold text-slate-100">{item.title}</h2>
+            <p className="mt-3 text-sm text-slate-300">{item.description}</p>
+            <p className="mt-6 text-sm text-indigo-300">Full briefings coming soon.</p>
           </article>
         ))}
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,50 +6,50 @@ const stats = [
 
 export default function Home() {
   return (
-    <main className="bg-white">
-      <section className="relative isolate overflow-hidden border-b bg-gradient-to-br from-white via-slate-50 to-slate-100">
+    <main className="bg-slate-950">
+      <section className="relative isolate overflow-hidden border-b border-slate-900 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
         <div className="mx-auto grid max-w-6xl gap-12 px-6 py-24 lg:grid-cols-2 lg:items-center">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-widest text-indigo-600">IPPAN Foundation</p>
-            <h1 className="mt-4 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            <p className="text-sm font-semibold uppercase tracking-widest text-indigo-400">IPPAN Foundation</p>
+            <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-100 sm:text-5xl">
               Empowering the Future of Decentralized Infrastructure
             </h1>
-            <p className="mt-6 text-lg text-gray-700">
+            <p className="mt-6 text-lg text-slate-300">
               The IPPAN Foundation is the steward of the IPPAN Network—an energy-efficient, massively scalable public blockchain
               built to support real-time financial transactions, machine-to-machine payments, and verifiable data availability
               across the globe.
             </p>
-            <p className="mt-4 text-lg text-gray-700">
+            <p className="mt-4 text-lg text-slate-300">
               We foster a secure, open, and resilient digital ecosystem where developers, businesses, and communities can build,
               innovate, and connect—free from centralized control.
             </p>
             <div className="mt-10 flex flex-wrap gap-4">
               <a
                 href="/about"
-                className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+                className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400"
               >
                 Join the Ecosystem
               </a>
               <a
                 href="#technology"
-                className="inline-flex items-center justify-center rounded-full border border-indigo-200 px-6 py-3 text-sm font-semibold text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-700"
+                className="inline-flex items-center justify-center rounded-full border border-indigo-500/50 px-6 py-3 text-sm font-semibold text-indigo-300 transition hover:border-indigo-400 hover:text-indigo-200"
               >
                 Explore Technology
               </a>
             </div>
           </div>
-          <div className="grid gap-6 rounded-3xl border bg-white/70 p-8 shadow-sm backdrop-blur">
-            <h2 className="text-lg font-semibold text-gray-900">IPPAN at a Glance</h2>
-            <p className="text-sm text-gray-600">
+          <div className="grid gap-6 rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-xl shadow-indigo-500/5 backdrop-blur">
+            <h2 className="text-lg font-semibold text-slate-100">IPPAN at a Glance</h2>
+            <p className="text-sm text-slate-300">
               Founded to protect the core protocol, govern open standards, and support ecosystem growth, the Foundation ensures the
               network remains neutral, decentralized, and censorship-resistant for the next generation of the internet and
               financial systems.
             </p>
-            <dl className="grid gap-4 text-sm text-gray-700 sm:grid-cols-2">
+            <dl className="grid gap-4 text-sm text-slate-300 sm:grid-cols-2">
               {stats.map((item) => (
                 <div key={item.label}>
-                  <dt className="font-medium text-gray-900">{item.label}</dt>
-                  <dd className="text-gray-600">{item.value}</dd>
+                  <dt className="font-medium text-slate-100">{item.label}</dt>
+                  <dd className="text-slate-400">{item.value}</dd>
                 </div>
               ))}
             </dl>
@@ -60,56 +60,56 @@ export default function Home() {
       <section className="mx-auto max-w-6xl px-6 py-24">
         <div className="grid gap-16 lg:grid-cols-[1.5fr,1fr] lg:items-start">
           <div>
-            <h2 className="text-3xl font-semibold tracking-tight text-gray-900">Mission & Mandate</h2>
-            <p className="mt-6 text-gray-700">
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-100">Mission & Mandate</h2>
+            <p className="mt-6 text-slate-300">
               As a non-profit organization, the IPPAN Foundation is committed to advancing the adoption and long-term sustainability
               of the IPPAN Network. We maintain and evolve the protocol, support developers and builders, and promote fair access
               and global participation so anyone can contribute to network resilience.
             </p>
             <div className="mt-10 grid gap-6 sm:grid-cols-2">
-              <div className="rounded-2xl border p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">Protocol Stewardship</h3>
-                <p className="mt-3 text-sm text-gray-600">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+                <h3 className="text-lg font-semibold text-slate-100">Protocol Stewardship</h3>
+                <p className="mt-3 text-sm text-slate-300">
                   Maintain and evolve the IPPAN protocol for security, performance, and interoperability with open standards.
                 </p>
               </div>
-              <div className="rounded-2xl border p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">Builder Support</h3>
-                <p className="mt-3 text-sm text-gray-600">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+                <h3 className="text-lg font-semibold text-slate-100">Builder Support</h3>
+                <p className="mt-3 text-sm text-slate-300">
                   Provide open tools, grants, and technical resources so innovators can launch applications with confidence.
                 </p>
               </div>
-              <div className="rounded-2xl border p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">Open Participation</h3>
-                <p className="mt-3 text-sm text-gray-600">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+                <h3 className="text-lg font-semibold text-slate-100">Open Participation</h3>
+                <p className="mt-3 text-sm text-slate-300">
                   Enable anyone to run nodes, earn rewards, and shape the network&apos;s future through transparent governance.
                 </p>
               </div>
-              <div className="rounded-2xl border p-6 shadow-sm">
-                <h3 className="text-lg font-semibold text-gray-900">Responsible Innovation</h3>
-                <p className="mt-3 text-sm text-gray-600">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+                <h3 className="text-lg font-semibold text-slate-100">Responsible Innovation</h3>
+                <p className="mt-3 text-sm text-slate-300">
                   Champion sustainability, regulatory clarity, and ethical deployment of decentralized infrastructure.
                 </p>
               </div>
             </div>
           </div>
-          <aside className="rounded-3xl border bg-slate-50 p-8 shadow-sm">
-            <h3 className="text-lg font-semibold text-gray-900">Community Programs</h3>
-            <ul className="mt-6 space-y-4 text-sm text-gray-600">
+          <aside className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40">
+            <h3 className="text-lg font-semibold text-slate-100">Community Programs</h3>
+            <ul className="mt-6 space-y-4 text-sm text-slate-300">
               <li>
-                <span className="font-medium text-gray-900">Developer Grants:</span> Funding open-source tools, libraries, and
+                <span className="font-medium text-slate-100">Developer Grants:</span> Funding open-source tools, libraries, and
                 decentralized applications.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Infrastructure Incentives:</span> Supporting node operators and
+                <span className="font-medium text-slate-100">Infrastructure Incentives:</span> Supporting node operators and
                 validators with fair rewards.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Education & Outreach:</span> Advancing blockchain literacy and
+                <span className="font-medium text-slate-100">Education & Outreach:</span> Advancing blockchain literacy and
                 training the next generation of builders.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Partnerships & Alliances:</span> Collaborating with academia,
+                <span className="font-medium text-slate-100">Partnerships & Alliances:</span> Collaborating with academia,
                 enterprises, and standards bodies worldwide.
               </li>
             </ul>
@@ -117,11 +117,11 @@ export default function Home() {
         </div>
       </section>
 
-      <section id="technology" className="border-y bg-slate-900 text-slate-100">
+      <section id="technology" className="border-y border-slate-900 bg-slate-900 text-slate-100">
         <div className="mx-auto grid max-w-6xl gap-12 px-6 py-24 lg:grid-cols-2 lg:items-center">
           <div>
             <h2 className="text-3xl font-semibold tracking-tight">Technology We Steward</h2>
-            <p className="mt-6 text-slate-200">
+            <p className="mt-6 text-slate-300">
               IPPAN introduces breakthrough innovations designed for real-world scale, enabling trust-minimized collaboration across
               finance, IoT, and data services.
             </p>
@@ -154,59 +154,59 @@ export default function Home() {
       <section className="mx-auto max-w-6xl px-6 py-24">
         <div className="grid gap-12 lg:grid-cols-2">
           <div>
-            <h2 className="text-3xl font-semibold tracking-tight text-gray-900">Governance & Transparency</h2>
-            <p className="mt-6 text-gray-700">
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-100">Governance & Transparency</h2>
+            <p className="mt-6 text-slate-300">
               The IPPAN Foundation ensures the network remains trustless and community-driven. Protocol upgrades, parameters, and
               treasury allocations are handled transparently, with community input every step of the way.
             </p>
-            <ul className="mt-8 space-y-4 text-sm text-gray-600">
+            <ul className="mt-8 space-y-4 text-sm text-slate-300">
               <li>
-                <span className="font-medium text-gray-900">Open Governance:</span> Major protocol decisions are openly debated,
+                <span className="font-medium text-slate-100">Open Governance:</span> Major protocol decisions are openly debated,
                 documented, and ratified.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Foundation Reserves:</span> Allocated responsibly to research,
+                <span className="font-medium text-slate-100">Foundation Reserves:</span> Allocated responsibly to research,
                 development, and ecosystem growth.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Compliance & Neutrality:</span> Supporting global participation while
+                <span className="font-medium text-slate-100">Compliance & Neutrality:</span> Supporting global participation while
                 respecting regional frameworks.
               </li>
             </ul>
           </div>
-          <div className="rounded-3xl border bg-white p-8 shadow-sm">
-            <h3 className="text-lg font-semibold text-gray-900">Get Involved</h3>
-            <p className="mt-4 text-sm text-gray-600">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40">
+            <h3 className="text-lg font-semibold text-slate-100">Get Involved</h3>
+            <p className="mt-4 text-sm text-slate-300">
               IPPAN is open to everyone—developers, entrepreneurs, researchers, and enthusiasts. Choose your path to contribute.
             </p>
-            <ul className="mt-6 space-y-4 text-sm text-gray-600">
+            <ul className="mt-6 space-y-4 text-sm text-slate-300">
               <li>
-                <span className="font-medium text-gray-900">Run a Node:</span> Strengthen security and earn rewards by operating
+                <span className="font-medium text-slate-100">Run a Node:</span> Strengthen security and earn rewards by operating
                 infrastructure.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Build on IPPAN:</span> Launch applications, integrate IoT networks,
+                <span className="font-medium text-slate-100">Build on IPPAN:</span> Launch applications, integrate IoT networks,
                 and deliver real-time financial services.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Contribute & Propose:</span> Join the conversation on protocol
+                <span className="font-medium text-slate-100">Contribute & Propose:</span> Join the conversation on protocol
                 evolution and standards.
               </li>
               <li>
-                <span className="font-medium text-gray-900">Support the Foundation:</span> Become a partner or donor to help
+                <span className="font-medium text-slate-100">Support the Foundation:</span> Become a partner or donor to help
                 advance the mission.
               </li>
             </ul>
             <div className="mt-8 flex flex-wrap gap-4">
               <a
                 href="/contact"
-                className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+                className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-500/30 transition hover:bg-indigo-400"
               >
                 Start Building
               </a>
               <a
                 href="/forum"
-                className="inline-flex items-center justify-center rounded-full border border-indigo-200 px-5 py-3 text-sm font-semibold text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-700"
+                className="inline-flex items-center justify-center rounded-full border border-indigo-500/50 px-5 py-3 text-sm font-semibold text-indigo-300 transition hover:border-indigo-400 hover:text-indigo-200"
               >
                 Join the Community Forum
               </a>


### PR DESCRIPTION
## Summary
- restyle the global layout with a night palette, dark backgrounds, and updated navigation/footer treatments
- refresh the home, about, contact, news, and forum pages to use high-contrast slate and indigo accents for the night theme
- invert typography styling on the legal page so prose reads correctly against the dark background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55bbbde44832bbfa005b0d37b531a