### PR TITLE
Update navigation to highlight UI portal

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,11 +74,23 @@ const organizationStructuredData = {
   ],
 }
 
-const navLinks = [
-  { href: '/', label: 'Home' },
+type NavLink = {
+  href: string
+  label: string
+  variant?: 'button'
+  external?: boolean
+}
+
+const navLinks: NavLink[] = [
   { href: '/about', label: 'About' },
   { href: '/news', label: 'News' },
   { href: '/forum', label: 'Forum' },
+  {
+    href: 'https://ui.ippan.org',
+    label: 'UI',
+    variant: 'button',
+    external: true,
+  },
   { href: '/contact', label: 'Contact' },
 ]
 
@@ -96,7 +108,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </Link>
               <nav aria-label="Primary" className="flex items-center gap-6 text-sm font-medium text-slate-300">
                 {navLinks.map((link) => (
-                  <Link key={link.href} href={link.href} className="transition hover:text-white">
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className={
+                      link.variant === 'button'
+                        ? 'rounded-full bg-cyan-400 px-4 py-1.5 text-slate-950 shadow transition hover:bg-cyan-300 hover:text-slate-950'
+                        : 'transition hover:text-white'
+                    }
+                    target={link.external ? '_blank' : undefined}
+                    rel={link.external ? 'noreferrer noopener' : undefined}
+                  >
                     {link.label}
                   </Link>
                 ))}


### PR DESCRIPTION
## Summary
- remove the Home item from the primary navigation
- add a highlighted UI button that links to https://ui.ippan.org after the Forum link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e32364a8832b87624587183e0478